### PR TITLE
Update readme - Change Next.js to React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ You can start editing the page by modifying `App.tsx`. The page auto-updates as 
 
 ## Learn More
 
-To learn more about thirdweb and Next.js, take a look at the following resources:
+To learn more about thirdweb and React Native, take a look at the following resources:
 
 - [thirdweb Portal](https://portal.thirdweb.com) - check our guides and development resources.
 - [thirdweb SDK](https://portal.thirdweb.com/sdk) - check our guides and development resources.
-- [React Native Documentation](https://reactnative.dev/) - learn about Next.js features and API.
+- [React Native Documentation](https://reactnative.dev/) - learn about React Native features and API.
 
 You can check out [the thirdweb GitHub organization](https://github.com/thirdweb-dev) - your feedback and contributions are welcome!
 


### PR DESCRIPTION
The Learn more section references Next js a couple of times instead of React Native